### PR TITLE
Python 3 support

### DIFF
--- a/pylatexenc/latex2text.py
+++ b/pylatexenc/latex2text.py
@@ -23,11 +23,13 @@
 #
 
 
+from __future__ import print_function, absolute_import
 import os
 import re
 import unicodedata
-import latexwalker
 import logging
+
+from pylatexenc import latexwalker
 
 
 logger = logging.getLogger(__name__);
@@ -498,7 +500,7 @@ class LatexNodes2Text(object):
         #
         
         if (len(n.nodeargs) != 1):
-            logger.warning(ur"Expected exactly one argument for '\input' ! Got = %r", n.nodeargs)
+            logger.warning(u"Expected exactly one argument for '\\input' ! Got = %r", n.nodeargs)
 
         inputtex = self.read_input_file(self.nodelist_to_text([n.nodeargs[0]]).strip())
 
@@ -663,17 +665,17 @@ if __name__ == '__main__':
 
         import fileinput
 
-        print "Please type some latex text (Ctrl+D twice to stop) ..."
+        print("Please type some latex text (Ctrl+D twice to stop) ...")
 
         latex = ''
         for line in fileinput.input():
             latex += line;
 
 
-        print '\n--- WORDS ---\n'
-        print latex2text(latex.decode('utf-8')#, keep_inline_math=True
-                         ).encode('utf-8')
-        print '\n-------------\n'
+        print('\n--- WORDS ---\n')
+        print(latex2text(latex.decode('utf-8')#, keep_inline_math=True
+                         ).encode('utf-8'))
+        print('\n-------------\n')
 
     except:
         import pdb;
@@ -681,7 +683,7 @@ if __name__ == '__main__':
         import sys;
         (exc_type, exc_value, exc_traceback) = sys.exc_info()
         
-        print "\nEXCEPTION: " + unicode(sys.exc_value) + "\n"
+        print("\nEXCEPTION: " + unicode(sys.exc_value) + "\n")
         
         pdb.post_mortem()
 

--- a/pylatexenc/latex2text.py
+++ b/pylatexenc/latex2text.py
@@ -28,6 +28,10 @@ import os
 import re
 import unicodedata
 import logging
+import sys
+if sys.version_info.major > 2:
+    def unicode(string): return string
+    basestring = str
 
 from pylatexenc import latexwalker
 

--- a/pylatexenc/latex2text.py
+++ b/pylatexenc/latex2text.py
@@ -687,8 +687,8 @@ if __name__ == '__main__':
         import sys;
         (exc_type, exc_value, exc_traceback) = sys.exc_info()
         
-        print("\nEXCEPTION: " + unicode(sys.exc_value) + "\n")
-        
+        print("\nEXCEPTION: " + unicode(sys.exc_info()[1]) + "\n")
+
         pdb.post_mortem()
 
 

--- a/pylatexenc/latexencode.py
+++ b/pylatexenc/latexencode.py
@@ -27,6 +27,10 @@
 from __future__ import print_function, absolute_import
 import unicodedata;
 import logging
+import sys
+if sys.version_info.major > 2:
+    def unicode(string): return string
+    basestring = str
 
 log = logging.getLogger(__name__)
 

--- a/pylatexenc/latexencode.py
+++ b/pylatexenc/latexencode.py
@@ -24,6 +24,7 @@
 #
 
 
+from __future__ import print_function, absolute_import
 import unicodedata;
 import logging
 
@@ -873,20 +874,20 @@ if __name__ == '__main__':
 
         import fileinput
 
-        print "Please type some unicode text (Ctrl+D twice to stop) ..."
+        print("Please type some unicode text (Ctrl+D twice to stop) ...")
 
         latex = ''
         for line in fileinput.input():
             latex += line;
 
-        print '\n--- LATEX ---\n'
-        print utf8tolatex(latex.decode('utf-8')).encode('utf-8')
-        print '\n-------------\n'
+        print('\n--- LATEX ---\n')
+        print(utf8tolatex(latex.decode('utf-8')).encode('utf-8'))
+        print('\n-------------\n')
 
     except:
         import pdb;
         import sys;
-        print "\nEXCEPTION: " + unicode(sys.exc_info()[1]) + "\n"
+        print("\nEXCEPTION: " + unicode(sys.exc_info()[1]) + "\n")
         pdb.post_mortem()
 
 

--- a/pylatexenc/latexwalker.py
+++ b/pylatexenc/latexwalker.py
@@ -31,8 +31,8 @@ import re
 from collections import namedtuple
 import sys
 if sys.version_info.major > 2:
+    def unicode(string): return string
     basestring = str
-
 
 
 class LatexWalkerError(Exception):

--- a/pylatexenc/latexwalker.py
+++ b/pylatexenc/latexwalker.py
@@ -23,6 +23,7 @@
 #
 
 
+from __future__ import print_function, absolute_import
 import logging
 logger = logging.getLogger(__name__)
 
@@ -1223,9 +1224,9 @@ def disp_node(n, indent=0, context='* ', skip_group=False):
         title = '\\begin{%s}' %(n.envname)
         iterchildren.append(('* ', n.nodelist, False));
     else:
-        print "UNKNOWN NODE TYPE: %s"%(n.nodeType().__name__)
+        print("UNKNOWN NODE TYPE: %s"%(n.nodeType().__name__))
 
-    print ' '*indent + context + title + '  '+comment
+    print(' '*indent + context + title + '  '+comment)
 
     for context, nodelist, skip in iterchildren:
         for nn in nodelist:
@@ -1252,18 +1253,18 @@ if __name__ == '__main__':
 
         (nodes, pos, llen) = get_latex_nodes(latex);
 
-        print '\n--- NODES ---\n'
-        print repr(nodes);
-        print '\n-------------\n'
+        print('\n--- NODES ---\n')
+        print(repr(nodes))
+        print('\n-------------\n')
 
-        print '\n--- NODES ---\n'
+        print('\n--- NODES ---\n')
         for n in nodes:
             disp_node(n)
-        print '\n-------------\n'
+        print('\n-------------\n')
 
     except:
         import pdb;
         import sys;
-        print "\nEXCEPTION: " + unicode(sys.exc_info()[1]) + "\n"
+        print("\nEXCEPTION: " + unicode(sys.exc_info()[1]) + "\n")
         pdb.post_mortem()
 

--- a/pylatexenc/latexwalker.py
+++ b/pylatexenc/latexwalker.py
@@ -29,6 +29,9 @@ logger = logging.getLogger(__name__)
 
 import re
 from collections import namedtuple
+import sys
+if sys.version_info.major > 2:
+    basestring = str
 
 
 

--- a/test/test_latexwalker.py
+++ b/test/test_latexwalker.py
@@ -1,4 +1,8 @@
 import unittest
+import sys
+if sys.version_info.major > 2:
+    def unicode(string): return string
+    basestring = str
 
 from pylatexenc.latexwalker import (
     MacrosDef, LatexWalker, LatexToken, LatexCharsNode, LatexGroupNode, LatexCommentNode,


### PR DESCRIPTION
Changes:
* Converted ur string prefix to u (fixes #1), 
* Converted print statements to use print() function (fixes #2)
* Converted relative imports to absolute imports (fixes #3).
* Define `basestring` if Python version greater than 2 (fixes #6).
* Define `unicode(s)` if Python version greater than 2 (fixes #7).
* Converted deprecated `sys.exc_value` to use `sys.exc_info()` instead (fixes #8)

The first three is enough to make ```import pylatexenc.latex2text``` work, the 4th is required to make ```pylatexenc.latex2text.latex2text(tex_string)``` run without errors, the 5th is required to run scripts and tests. 

With these four updates, ```pylatexenc.latex2text.latex2text(tex_string)``` now executes without errors on Python 3.6.

Note that there are more "canonical" ways of achieving python 2+3 compatibility, e.g. through the use of the `six` module. 

It may be useful to add these to `requirements.txt`: `future`, and `six` (the former comes standard with python 2.7 and python 3+).

