### PR TITLE
Fix the disappearance of spaces before `LatexToken`s other than those of 'char'

### DIFF
--- a/pylatexenc/latexwalker.py
+++ b/pylatexenc/latexwalker.py
@@ -893,7 +893,7 @@ class LatexWalker(object):
             #    p.lastchars += tok.pre_space # yields wayyy tooo much space in output!!
 
             # if it's not a char, push the last `p.lastchars` into the node list before anything else
-            if (len(p.lastchars)):
+            if (len(p.lastchars) or len(tok.pre_space)):
                 strnode = LatexCharsNode(chars=p.lastchars+tok.pre_space)
                 nodelist.append(strnode)
                 p.lastchars = '' # reset lastchars.


### PR DESCRIPTION
This modification in latexwalker.py will fix #15 and a part of @tim6her 's issue #11 .

To make this package to closely follow LaTeX's behavior (to fix the remaining issue in #11 ), I think it's better to modify LatexNodes2Text().latex_to_text(), because the present implementation deals with the spaces as belongings of the token that follow(LatexToken.pre_space), whereas LaTeX's behavior is brought by the fact that a space immediately AFTER a macro is used/eaten up as a separator/delimiter of the macro.