### PR TITLE
Include resources needed by tests in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include LICENSE.txt
+include test/uni_chars_test_previous.txt test/test_input_1.tex test/dummy/readme.txt


### PR DESCRIPTION
While attempting to package `pylatexenc` using as a source the pypi-distributed sdist (ie. `pylatexenc-2.1.tar.gz`), a couple of tests (`TestLatexNodes2Text.test_input`, `TestLatexEncode.test_all`) seem to be erroring.

Digging a bit, it seems the cause is that the non-py files in the `test/` folder were not included in the .tar.gz distributable, and they are needed by the tests - this PR is a suggestion for including them in the resulting file, in the hopes of being able to run the full test suite accordingly using solely the sdist in future releases:

* `test/uni_chars_test_previous.txt`
* `test/test_input_1.tex`
* `test/dummy/readme.txt`

