### PR TITLE
Fix never ending loop

### DIFF
--- a/test/test_latexwalker.py
+++ b/test/test_latexwalker.py
@@ -1211,6 +1211,20 @@ Use macros: """,
                                pos=1+31, len=2),
             ], p, 34))
 
+    def test_invalid_env_macros(self):
+        latextext = r'''
+            \begin
+            \item {1.} Example text 1
+            \item {2.} Example text 2
+            \item {3.} Example text 3
+            \item {4.} Example text 4
+            \end
+        '''
+
+        walker = LatexWalker(latextext)
+        nodes = walker.get_latex_nodes()[0]
+        self.assertEqual(nodes, [])
+
 
 
 


### PR DESCRIPTION
This PR addresses issue https://github.com/phfaist/pylatexenc/issues/37, taking the proposed approach: _"log and ignore"_.

In order to do so, I have defined:
- A new exception: `LatexWalkerInvalidEnv`, which refer to wrongly defined `\begin` and `\end` environment dependent macros.
- A new test to check that this infinite loop bug does not happens again.