### PR TITLE
add "upgreek" macro spec

### DIFF
--- a/pylatexenc/latex2text/_defaultspecs.py
+++ b/pylatexenc/latex2text/_defaultspecs.py
@@ -1,19 +1,19 @@
 # -*- coding: utf-8 -*-
 #
 # The MIT License (MIT)
-# 
+#
 # Copyright (c) 2019 Philippe Faist
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -182,7 +182,7 @@ _latex_specs_approximations = {
         ) ,
         ('footnote', '[%(2)s]'), # \footnote[optional mark]{footnote text}
         ('href', lambda n, l2tobj:  \
-         '{} <{}>'.format(l2tobj.nodelist_to_text([n.nodeargd.argnlist[1]]), 
+         '{} <{}>'.format(l2tobj.nodelist_to_text([n.nodeargd.argnlist[1]]),
                           l2tobj.nodelist_to_text([n.nodeargd.argnlist[0]]))),
 
         ('cite', '<cit.>'),
@@ -226,7 +226,7 @@ _latex_specs_approximations = {
 }
 
 _latex_specs_base = {
-    
+
     'environments': [
     ],
     'specials': [
@@ -394,7 +394,7 @@ _latex_specs_base = {
         ('arccosh', 'arccosh'),
         ('arcsinh', 'arcsinh'),
         ('arctanh', 'arctanh'),
-        
+
         ('ln', 'ln'),
         ('log', 'log'),
 
@@ -1461,6 +1461,14 @@ def _greekletters(letterlist):
         _latex_specs_base['macros'].append(
             MacroTextSpec(l[0].upper()+l[1:], unicodedata.lookup("GREEK CAPITAL LETTER "+ucharname))
             )
+        # up-greek version (from packages such as upgreek or newtxmath)
+        _latex_specs_base['macros'].append(
+            MacroTextSpec(f"up{l}", unicodedata.lookup(smallname))
+        )
+        _latex_specs_base['macros'].append(
+            MacroTextSpec(f"Up{l}", unicodedata.lookup("GREEK CAPITAL LETTER "+ucharname))
+            )
+
 _greekletters(
     ('alpha', 'beta', 'gamma', 'delta', 'epsilon', 'zeta', 'eta', 'theta', 'iota', 'kappa',
      'lambda', 'mu', 'nu', 'xi', 'omicron', 'pi', 'rho', 'sigma', 'tau', 'upsilon', 'phi',
@@ -1473,6 +1481,13 @@ _latex_specs_base['macros'] += [
     MacroTextSpec('varrho', u'\N{GREEK RHO SYMBOL}'),
     MacroTextSpec('varsigma', u'\N{GREEK SMALL LETTER FINAL SIGMA}'),
     MacroTextSpec('varphi', u'\N{GREEK SMALL LETTER PHI}'),
+    # up-greek version
+    MacroTextSpec('upvarepsilon', u'\N{GREEK SMALL LETTER EPSILON}'),
+    MacroTextSpec('upvartheta', u'\N{GREEK THETA SYMBOL}'),
+    MacroTextSpec('upvarpi', u'\N{GREEK PI SYMBOL}'),
+    MacroTextSpec('upvarrho', u'\N{GREEK RHO SYMBOL}'),
+    MacroTextSpec('upvarsigma', u'\N{GREEK SMALL LETTER FINAL SIGMA}'),
+    MacroTextSpec('upvarphi', u'\N{GREEK SMALL LETTER PHI}'),
     ]
 
 
@@ -1536,4 +1551,3 @@ for u in unicode_accents_list:
     )
 
 # specs structure now complete
-

--- a/test/test_latex2text_upgreek.py
+++ b/test/test_latex2text_upgreek.py
@@ -1,0 +1,67 @@
+import unittest
+
+from pylatexenc.latexwalker import LatexWalker
+from pylatexenc.latex2text import LatexNodes2Text
+
+
+upgreek_letters = (
+    (r"\upmu", "μ"),
+    (r"\upalpha", "α"),
+    (r"\upbeta", "β"),
+    (r"\upgamma", "γ"),
+    (r"\updelta", "δ"),
+    (r"\upepsilon", "ϵ"),     # not sure...
+    (r"\upvarepsilon", "ε"),  #
+    (r"\upzeta", "ζ"),
+    (r"\upeta", "η"),
+    (r"\uptheta", "θ"),     # not sure...
+    (r"\upvartheta", "ϑ"),  #
+    (r"\upiota", "ι"),
+    (r"\upkappa", "κ"),
+    (r"\uplambda", "λ"),
+    (r"\upmu", "μ"),
+    (r"\upnu", "ν"),
+    (r"\upxi", "ξ"),
+    (r"\uppi", "π"),
+    (r"\upvarpi", "ϖ"),
+    (r"\uprho", "ρ"),     # not sure...
+    (r"\upvarrho", "ϱ"),  #
+    (r"\upsigma", "σ"),     # not sure...
+    (r"\upvarsigma", "ς"),  #
+    (r"\uptau", "τ"),
+    (r"\upupsilon", "υ"),
+    (r"\upphi", "ϕ"),     # not sure...
+    (r"\upvarphi", "φ"),  # NB: 'ϕ' != 'φ'
+    (r"\upchi", "χ"),
+    (r"\uppsi", "ψ"),
+    (r"\upomega", "ω"),
+    #
+    (r"\Upgamma", "Γ"),
+    (r"\Updelta", "Δ"),
+    (r"\Uptheta", "Θ"),
+    (r"\Uplambda", "Λ"),
+    (r"\Upxi", "Ξ"),
+    (r"\Uppi", "Π"),
+    (r"\Upsigma", "Σ"),
+    (r"\Upupsilon", "Υ"),
+    (r"\Upphi", "Φ"),
+    (r"\Uppsi", "Ψ"),
+    (r"\Upomega", "Ω"),
+)
+
+
+class TestLatexNodes2TextUpgreek(unittest.TestCase):
+
+    def __init__(self, *args, **kwargs):
+        # super(TestLatexNodes2Text, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
+        # self.maxDiff = None
+
+    def test_upgreek(self):
+        for source, expected_dest in upgreek_letters:
+            with self.subTest():
+                self.assertEqual(
+                    LatexNodes2Text().nodelist_to_text(
+                        LatexWalker(source).get_latex_nodes()[0]),
+                    expected_dest
+                )


### PR DESCRIPTION
Packages like [upgreek](https://ctan.org/pkg/upgreek) and [newtxmath](https://ctan.org/pkg/newtx) provide an "upright" version of greek letters.