### PR TITLE
Add verbatim parsing of lstlisting environments

### DIFF
--- a/pylatexenc/latexwalker/_defaultspecs.py
+++ b/pylatexenc/latexwalker/_defaultspecs.py
@@ -28,7 +28,7 @@
 
 
 from ..macrospec import std_macro, std_environment, std_specials, \
-    MacroSpec, EnvironmentSpec, MacroStandardArgsParser, VerbatimArgsParser
+    MacroSpec, EnvironmentSpec, MacroStandardArgsParser, VerbatimArgsParser, LstListingArgsParser
 
 specs = [
     #
@@ -306,6 +306,16 @@ specs = [
         'specials': [
             # optionally users could include the specials "|" like in latex-doc
             # for verbatim |\like \this|...
+        ]}),
+
+    ('lstlisting', {
+        'macros': [],
+        'environments': [
+            EnvironmentSpec('lstlisting', args_parser=LstListingArgsParser()),
+        ],
+        'specials': [
+            # optionally users could include the specials "|" like in latex-doc
+            # for lstlisting |\like \this|...
         ]}),
 
     #

--- a/pylatexenc/macrospec/__init__.py
+++ b/pylatexenc/macrospec/__init__.py
@@ -54,7 +54,7 @@ else:
 # ------------------------------------------------------------------------------
 
 from ._argparsers import ParsedMacroArgs, MacroStandardArgsParser, \
-    ParsedVerbatimArgs, VerbatimArgsParser
+    ParsedVerbatimArgs, VerbatimArgsParser, ParsedLstListingArgs, LstListingArgsParser
 
 # ------------------------------------------------------------------------------
 

--- a/pylatexenc/macrospec/_argparsers.py
+++ b/pylatexenc/macrospec/_argparsers.py
@@ -400,18 +400,20 @@ class ParsedVerbatimArgs(ParsedMacroArgs):
         self.verbatim_delimiters = verbatim_delimiters
 
     def __repr__(self):
-        return "{}(verbatim_text={!r}, verbatim_delimiters={!r})".format(
-            self.__class__.__name__, self.verbatim_text, self.verbatim_delimiters
+        return (
+            "{}(verbatim_text={!r}, verbatim_delimiters={!r}) [{!r}]"
+            .format(
+                self.__class__.__name__,
+                self.verbatim_text, self.verbatim_delimiters,
+                super(ParsedVerbatimArgs, self).__repr__()
+            )
         )
 
 
-class ParsedLstListingArgs(ParsedMacroArgs):
+class ParsedLstListingArgs(ParsedVerbatimArgs):
     r"""
     Parsed representation of arguments to a LaTeX lstlisting environment, i.e.
     ``\begin{lstlisting}...\end{lstlisting}``
-
-    Instances of `ParsedLstListingArgs` are returned by the args parser
-    :py:class:`LstListingArgsParser`.
 
     Arguments:
 
@@ -434,6 +436,8 @@ class ParsedLstListingArgs(ParsedMacroArgs):
         # not "lstlisting environment-aware" sees this simply as the argument to
         # an empty lstlisting environment
         super(ParsedLstListingArgs, self).__init__(
+            verbatim_chars_node=,
+            verbatim_delimiters=,........
             argspec='{',
             argnlist=[lstlisting_chars_node],
             **kwargs
@@ -441,9 +445,15 @@ class ParsedLstListingArgs(ParsedMacroArgs):
         
         self.lstlisting_text = lstlisting_chars_node.chars
 
+
     def __repr__(self):
-        return "{}(lstlisting_text={!r})".format(
-            self.__class__.__name__, self.lstlisting_text
+        return (
+            "{}(lstlisting_text={!r}) [{!r}]"
+            .format(
+                self.__class__.__name__,
+                self.lstlisting_text,
+                super(ParsedLstListingArgs, self).__repr__()
+            )
         )
 
 

--- a/pylatexenc/macrospec/_argparsers.py
+++ b/pylatexenc/macrospec/_argparsers.py
@@ -430,20 +430,18 @@ class ParsedLstListingArgs(ParsedVerbatimArgs):
 
        The lstlisting text that was provided
     """
-    def __init__(self, lstlisting_chars_node, **kwargs):
+    def __init__(self, chars_node, **kwargs):
 
         # provide argspec/argnlist to the parent class so that any code that is
         # not "lstlisting environment-aware" sees this simply as the argument to
         # an empty lstlisting environment
         super(ParsedLstListingArgs, self).__init__(
-            verbatim_chars_node=,
-            verbatim_delimiters=,........
-            argspec='{',
-            argnlist=[lstlisting_chars_node],
+            verbatim_chars_node=chars_node,
+            verbatim_delimiters=None,
             **kwargs
         )
         
-        self.lstlisting_text = lstlisting_chars_node.chars
+        self.lstlisting_text = chars_node.chars
 
 
     def __repr__(self):
@@ -568,7 +566,7 @@ class LstListingArgsParser(MacroStandardArgsParser):
         len_ = endverbpos-pos
 
         argd = ParsedLstListingArgs(
-            lstlisting_chars_node=w.make_node(latexwalker.LatexCharsNode,
+            chars_node=w.make_node(latexwalker.LatexCharsNode,
                                             parsing_state=parsing_state,
                                             chars=w.s[pos:pos+len_],
                                             pos=pos,

--- a/pylatexenc/macrospec/_argparsers.py
+++ b/pylatexenc/macrospec/_argparsers.py
@@ -578,7 +578,7 @@ class VerbatimArgsParser(MacroStandardArgsParser):
                                                 chars=w.s[pos:pos+len_],
                                                 pos=pos,
                                                 len=len_),
-                **parsed_args_object_kwargs,
+                **parsed_args_object_kwargs
             )
             return (argd, pos_start, endverbpos - pos_start)
 
@@ -605,7 +605,7 @@ class VerbatimArgsParser(MacroStandardArgsParser):
                                                 pos=pos,
                                                 len=endpos-pos),
                 verbatim_delimiters=self.specials_delimiters,
-                **parsed_args_object_kwargs,
+                **parsed_args_object_kwargs
             )
 
             return (argd, pos_start, endpos+1-pos_start) # include delimiters in pos/len
@@ -643,7 +643,7 @@ class VerbatimArgsParser(MacroStandardArgsParser):
                                                 pos=beginpos,
                                                 len=endpos-beginpos),
                 verbatim_delimiters=(verbdelimchar, verbdelimchar),
-                **parsed_args_object_kwargs,
+                **parsed_args_object_kwargs
             )
 
             return (argd, pos_start, endpos+1-pos_start) # include delimiters in pos/len

--- a/test/test_latexwalker.py
+++ b/test/test_latexwalker.py
@@ -1050,41 +1050,53 @@ This is it."""
             167)
         )
 
-    def test_handling(self):
+    def test_lstlisting_handling(self):
 
-        doc = r"""Use lstlisting environment for code
+        s = r"""Use lstlisting environment for code
 \begin{lstlisting}
 int foo() {
-    // This function produces an error
+    "^\\[1-9]+\n$" // some special chars
+    // unmatched open brace confuses non-verbatim parsing
 \end{lstlisting}
 This is it."""
 
-        lw = LatexWalker(doc)
+        lw = LatexWalker(s)
 
         parsing_state = lw.make_parsing_state()
+
+        print(lw.get_latex_nodes(pos=0, parsing_state=parsing_state)[0][1])
 
         p=0
         self.assertEqual(
             lw.get_latex_nodes(pos=p, parsing_state=parsing_state),
             ([
-                LatexCharsNode(parsing_state=parsing_state, pos=0, len=36,
+                LatexCharsNode(parsing_state=parsing_state, pos=0, len=(53-18)+1,
                                chars='Use lstlisting environment for code\n'),
                 LatexEnvironmentNode(
-                    parsing_state=parsing_state, pos=36, len=86,
-                    environmentname='lstlisting', nodelist=[],
+                    parsing_state=parsing_state,
+                    pos=(53-18)+1, len=19+12+41+58+16,
+                    environmentname='lstlisting',
+                    nodelist=[],
                     nodeargd=macrospec.ParsedLstListingArgs(
                         lstlisting_chars_node=
                         LatexCharsNode(
-                            parsing_state=parsing_state, pos=54, len=52,
-                            chars='\nint foo() {\n    // This function produces an error\n'
+                            parsing_state=parsing_state,
+                            pos=(53-18)+1+18,
+                            len=1+12+41+58,
+                            chars=r"""
+int foo() {
+    "^\\[1-9]+\n$" // some special chars
+    // unmatched open brace confuses non-verbatim parsing
+"""
                         ),
                     )
                 ),
-                LatexCharsNode(parsing_state=parsing_state, pos=122, len=12,
+                LatexCharsNode(parsing_state=parsing_state,
+                               pos=s.find(r'\end{lstlisting}')+16, len=12,
                                chars='\nThis is it.')
             ],
             0,
-            134)
+            len(s))
         )
 
     def test_parsing_state_changes(self):

--- a/test/test_latexwalker.py
+++ b/test/test_latexwalker.py
@@ -1050,6 +1050,101 @@ This is it."""
             167)
         )
 
+    def test_verbatim_via_specials(self):
+
+        latextext = r"""
+Use the |\verb| command or the
+|\begin{verbatim}| ... |\end{verbatim}| environment
+to typeset verbatim text!
+
+Syntax errors within verbatim content, such as |{|, should
+not cause processing problems.
+"""
+
+        walker_context = get_default_latex_context_db()
+        walker_context.add_context_category(
+            'specials-verbatim',
+            specials=[
+                macrospec.SpecialsSpec('|', args_parser=macrospec.VerbatimArgsParser(
+                    verbatim_arg_type='specials-delimiters',
+                    specials_delimiters=('|', '|'),
+                )),
+            ],
+            prepend=True
+        )
+
+        lw = LatexWalker(latextext, latex_context=walker_context)
+
+        parsing_state = lw.make_parsing_state()
+
+        p=0
+        self.assertEqual(
+            lw.get_latex_nodes(pos=p, parsing_state=parsing_state),
+            ([
+                LatexCharsNode(parsing_state=parsing_state, pos=0, len=1+8,
+                               chars='\nUse the '),
+                LatexSpecialsNode(
+                    parsing_state=parsing_state, pos=1+8, len=15-8,
+                    specials_chars='|',
+                    nodeargd=macrospec.ParsedVerbatimArgs(
+                        verbatim_chars_node=
+                        LatexCharsNode(parsing_state=parsing_state, pos=1+9, len=14-9,
+                                       chars='\\verb'),
+                        verbatim_delimiters=('|', '|'),
+                    )
+                ),
+                LatexCharsNode(parsing_state=parsing_state, pos=1+15, len=(30-15)+1,
+                               chars=' command or the\n'),
+                LatexSpecialsNode(
+                    parsing_state=parsing_state, pos=1+31, len=18-0,
+                    specials_chars='|',
+                    nodeargd=macrospec.ParsedVerbatimArgs(
+                        verbatim_chars_node=
+                        LatexCharsNode(parsing_state=parsing_state, pos=1+31+1, len=17-1,
+                                       chars='\\begin{verbatim}'),
+                        verbatim_delimiters=('|', '|'),
+                    )
+                ),
+                LatexCharsNode(parsing_state=parsing_state, pos=1+31+18, len=23-18,
+                               chars=' ... '),
+                LatexSpecialsNode(
+                    parsing_state=parsing_state, pos=1+31+23, len=39-23,
+                    specials_chars='|',
+                    nodeargd=macrospec.ParsedVerbatimArgs(
+                        verbatim_chars_node=
+                        LatexCharsNode(parsing_state=parsing_state, pos=1+31+24, len=38-24,
+                                       chars='\\end{verbatim}'),
+                        verbatim_delimiters=('|', '|'),
+                    )
+                ),
+                LatexCharsNode(parsing_state=parsing_state,
+                               pos=1+31+39, len=(52-39)+26+1+47,
+                               chars=r""" environment
+to typeset verbatim text!
+
+Syntax errors within verbatim content, such as """),
+                LatexSpecialsNode(
+                    parsing_state=parsing_state, pos=1+31+52+26+1+47, len=3,
+                    specials_chars='|',
+                    nodeargd=macrospec.ParsedVerbatimArgs(
+                        verbatim_chars_node=
+                        LatexCharsNode(parsing_state=parsing_state,
+                                       pos=1+31+52+26+1+48, len=1,
+                                       chars='{'),
+                        verbatim_delimiters=('|', '|'),
+                    )
+                ),
+                LatexCharsNode(parsing_state=parsing_state,
+                               pos=1+31+52+26+1+50, len=(59-50)+31,
+                               chars=r""", should
+not cause processing problems.
+"""),
+            ],
+            0,
+            len(latextext),
+            )
+        )
+
     def test_lstlisting_handling(self):
 
         s = r"""Use lstlisting environment for code
@@ -1064,6 +1159,7 @@ This is it."""
 
         parsing_state = lw.make_parsing_state()
 
+        print("DEBUG")
         print(lw.get_latex_nodes(pos=0, parsing_state=parsing_state)[0][1])
 
         p=0
@@ -1078,7 +1174,7 @@ This is it."""
                     environmentname='lstlisting',
                     nodelist=[],
                     nodeargd=macrospec.ParsedLstListingArgs(
-                        chars_node=
+                        verbatim_chars_node=
                         LatexCharsNode(
                             parsing_state=parsing_state,
                             pos=(53-18)+1+18,
@@ -1089,6 +1185,8 @@ int foo() {
     // unmatched open brace confuses non-verbatim parsing
 """
                         ),
+                        verbatim_argspec='[',
+                        verbatim_argnlist=[None],
                     )
                 ),
                 LatexCharsNode(parsing_state=parsing_state,
@@ -1098,6 +1196,76 @@ int foo() {
             0,
             len(s))
         )
+
+    def test_lstlisting_withoptarg(self):
+
+        latextext = r"""Use lstlisting environment for code
+\begin{lstlisting}[language=C]
+int foo() {
+    "^\\[1-9]+\n$" // some special chars
+    // unmatched open brace confuses non-verbatim parsing
+\end{lstlisting}
+This is it."""
+
+        lw = LatexWalker(latextext)
+
+        parsing_state = lw.make_parsing_state()
+
+        print("DEBUG")
+        print(lw.get_latex_nodes(pos=0, parsing_state=parsing_state)[0][1])
+
+        p=0
+        self.assertEqual(
+            lw.get_latex_nodes(pos=p, parsing_state=parsing_state),
+            ([
+                LatexCharsNode(parsing_state=parsing_state, pos=0, len=(60-24),
+                               chars='Use lstlisting environment for code\n'),
+                LatexEnvironmentNode(
+                    parsing_state=parsing_state,
+                    pos=(60-24), len=31+12+41+58+16,
+                    environmentname='lstlisting',
+                    nodelist=[],
+                    nodeargd=macrospec.ParsedLstListingArgs(
+                        verbatim_chars_node=
+                        LatexCharsNode(
+                            parsing_state=parsing_state,
+                            pos=(60-24)+30,
+                            len=1+12+41+58,
+                            chars=r"""
+int foo() {
+    "^\\[1-9]+\n$" // some special chars
+    // unmatched open brace confuses non-verbatim parsing
+"""
+                        ),
+                        verbatim_argspec='[',
+                        verbatim_argnlist=[
+                            LatexGroupNode(
+                                parsing_state=parsing_state,
+                                pos=(60-24)+18, len=30-18,
+                                nodelist=[
+                                    LatexCharsNode(parsing_state=parsing_state,
+                                                   pos=(60-24)+19,
+                                                   len=29-19,
+                                                   chars='language=C')
+                                ],
+                                delimiters=('[', ']'),
+                            )
+                        ],
+                    )
+                ),
+                LatexCharsNode(parsing_state=parsing_state,
+                               pos=latextext.find(r'\end{lstlisting}')+16, len=12,
+                               chars='\nThis is it.')
+            ],
+            0,
+            len(latextext))
+        )
+
+
+
+
+
+
 
     def test_parsing_state_changes(self):
 

--- a/test/test_latexwalker.py
+++ b/test/test_latexwalker.py
@@ -1078,7 +1078,7 @@ This is it."""
                     environmentname='lstlisting',
                     nodelist=[],
                     nodeargd=macrospec.ParsedLstListingArgs(
-                        lstlisting_chars_node=
+                        chars_node=
                         LatexCharsNode(
                             parsing_state=parsing_state,
                             pos=(53-18)+1+18,

--- a/test/test_latexwalker.py
+++ b/test/test_latexwalker.py
@@ -1050,6 +1050,42 @@ This is it."""
             167)
         )
 
+    def test_handling(self):
+
+        doc = r"""Use lstlisting environment for code
+\begin{lstlisting}
+int foo() {
+    // This function produces an error
+\end{lstlisting}
+This is it."""
+
+        lw = LatexWalker(doc)
+
+        parsing_state = lw.make_parsing_state()
+
+        p=0
+        self.assertEqual(
+            lw.get_latex_nodes(pos=p, parsing_state=parsing_state),
+            ([
+                LatexCharsNode(parsing_state=parsing_state, pos=0, len=36,
+                               chars='Use lstlisting environment for code\n'),
+                LatexEnvironmentNode(
+                    parsing_state=parsing_state, pos=36, len=86,
+                    environmentname='lstlisting', nodelist=[],
+                    nodeargd=macrospec.ParsedLstListingArgs(
+                        lstlisting_chars_node=
+                        LatexCharsNode(
+                            parsing_state=parsing_state, pos=54, len=52,
+                            chars='\nint foo() {\n    // This function produces an error\n'
+                        ),
+                    )
+                ),
+                LatexCharsNode(parsing_state=parsing_state, pos=122, len=12,
+                               chars='\nThis is it.')
+            ],
+            0,
+            134)
+        )
 
     def test_parsing_state_changes(self):
 


### PR DESCRIPTION
The pull request fixes the parsing of the lstlisting environment which should be similar to the verbatim environment. Since I am not deeply familiar with the code base, most diff is basically copy-pasted from the verbatim environment (without the additional parameterization for the macro).

I added a test case which contains source code with a single opening curly bracket. If the lstlisting environment is not parsed verbatim, this corrupts the parse tree (every node after the lstlisting environment becomes a child of the environment).