### PR TITLE
deprecate isNodeType, nodeType

### DIFF
--- a/pylatexenc/latex2text/__init__.py
+++ b/pylatexenc/latex2text/__init__.py
@@ -379,11 +379,11 @@ def fmt_matrix_environment_node(node, l2tobj):
 
     # iterate the nodelist and find column and row separators
     for n in node.nodelist:
-        if n.isNodeType(latexwalker.LatexSpecialsNode) and n.specials_chars == '&':
+        if isinstance(n, latexwalker.LatexSpecialsNode) and n.specials_chars == '&':
             # column separator
             state.new_column()
             continue
-        if n.isNodeType(latexwalker.LatexMacroNode) and n.macroname == "\\":
+        if isinstance(n, latexwalker.LatexMacroNode) and n.macroname == "\\":
             # row separator
             state.new_row()
             continue
@@ -1028,7 +1028,7 @@ class LatexNodes2Text(object):
         prev_node = None
         for node in nodelist:
             if self._is_bare_macro_node(prev_node) and \
-               node.isNodeType(latexwalker.LatexCharsNode):
+               isinstance(node, latexwalker.LatexCharsNode):
 
                 if not self.strict_latex_spaces['between-macro-and-chars']:
                     # after a macro with absolutely no arguments, include
@@ -1066,25 +1066,25 @@ class LatexNodes2Text(object):
         # ### It doesn't look like we use prev_node_hint at all.  Eliminate at
         # ### some point?
 
-        if node.isNodeType(latexwalker.LatexCharsNode):
+        if isinstance(node, latexwalker.LatexCharsNode):
             return self.chars_node_to_text(node, textcol=textcol)
 
-        if node.isNodeType(latexwalker.LatexCommentNode):
+        if isinstance(node, latexwalker.LatexCommentNode):
             return self.comment_node_to_text(node)
 
-        if node.isNodeType(latexwalker.LatexGroupNode):
+        if isinstance(node, latexwalker.LatexGroupNode):
             return self.group_node_to_text(node)
 
-        if node.isNodeType(latexwalker.LatexMacroNode):
+        if isinstance(node, latexwalker.LatexMacroNode):
             return self.macro_node_to_text(node)
 
-        if node.isNodeType(latexwalker.LatexEnvironmentNode):
+        if isinstance(node, latexwalker.LatexEnvironmentNode):
             return self.environment_node_to_text(node)
 
-        if node.isNodeType(latexwalker.LatexSpecialsNode):
+        if isinstance(node, latexwalker.LatexSpecialsNode):
             return self.specials_node_to_text(node)
 
-        if node.isNodeType(latexwalker.LatexMathNode):
+        if isinstance(node, latexwalker.LatexMathNode):
             return self.math_node_to_text(node)
 
         logger.warning("LatexNodes2Text.node_to_text(): Unknown node: %r", node)
@@ -1237,7 +1237,7 @@ class LatexNodes2Text(object):
         """
 
         if self.math_mode == 'verbatim':
-            if node.isNodeType(latexwalker.LatexEnvironmentNode) \
+            if isinstance(node, latexwalker.LatexEnvironmentNode) \
                or node.displaytype == 'display':
                 return self._fmt_indented_block(node.latex_verbatim(), indent='')
             else:
@@ -1249,12 +1249,12 @@ class LatexNodes2Text(object):
         elif self.math_mode == 'with-delimiters':
             with _PushEquationContext(self):
                 content = self.nodelist_to_text(node.nodelist).strip()
-            if node.isNodeType(latexwalker.LatexMathNode):
+            if isinstance(node, latexwalker.LatexMathNode):
                 delims = node.delimiters
             else: # environment node
                 delims = (r'\begin{%s}'%(node.environmentname),
                           r'\end{%s}'%(node.environmentname),)
-            if node.isNodeType(latexwalker.LatexEnvironmentNode) \
+            if isinstance(node, latexwalker.LatexEnvironmentNode) \
                or node.displaytype == 'display':
                 return delims[0] + self._fmt_indented_block(content, indent='') + delims[1]
             else:
@@ -1263,7 +1263,7 @@ class LatexNodes2Text(object):
         elif self.math_mode == 'text':
             with _PushEquationContext(self):
                 content = self.nodelist_to_text(node.nodelist).strip()
-            if node.isNodeType(latexwalker.LatexEnvironmentNode) \
+            if isinstance(node, latexwalker.LatexEnvironmentNode) \
                or node.displaytype == 'display':
                 return self._fmt_indented_block(content)
             else:
@@ -1325,13 +1325,13 @@ class LatexNodes2Text(object):
             if 'l2tobj' in fn_args:
                 # callable accepts an argument named 'l2tobj', provide pointer to self
                 kwargs['l2tobj'] = self
-            if node.isNodeType(latexwalker.LatexEnvironmentNode) and \
+            if isinstance(node, latexwalker.LatexEnvironmentNode) and \
                'environmentname' in fn_args:
                 kwargs['environmentname'] = node.environmentname
-            if node.isNodeType(latexwalker.LatexMacroNode) and \
+            if isinstance(node, latexwalker.LatexMacroNode) and \
                'macroname' in fn_args:
                 kwargs['macroname'] = node.macroname
-            if node.isNodeType(latexwalker.LatexSpecialsNode) and \
+            if isinstance(node, latexwalker.LatexSpecialsNode) and \
                'specials_chars' in fn_args:
                 kwargs['specials_chars'] = node.specials_chars
 
@@ -1352,7 +1352,7 @@ class LatexNodes2Text(object):
 
             has_percent_s = re.search('(^|[^%])(%%)*%s', simplify_repl)
 
-            if node.isNodeType(latexwalker.LatexEnvironmentNode):
+            if isinstance(node, latexwalker.LatexEnvironmentNode):
                 if has_percent_s:
                     x = (self.nodelist_to_text(node.nodelist), )
                 else:
@@ -1392,14 +1392,14 @@ class LatexNodes2Text(object):
 
     def _is_bare_macro_node(self, node):
         return (node is not None and
-                node.isNodeType(latexwalker.LatexMacroNode) and
+                isinstance(node, latexwalker.LatexMacroNode) and
                 node.nodeoptarg is None and
                 len(node.nodeargs) == 0)
 
     def _groupnodecontents_to_text(self, groupnode):
         if groupnode is None:
             return ''
-        if not groupnode.isNodeType(latexwalker.LatexGroupNode):
+        if not isinstance(groupnode, latexwalker.LatexGroupNode):
             return self.node_to_text(groupnode)
         return self.nodelist_to_text(groupnode.nodelist)
 

--- a/pylatexenc/latexwalker/__init__.py
+++ b/pylatexenc/latexwalker/__init__.py
@@ -51,7 +51,7 @@ Simple example usage::
     nodeargd=ParsedMacroArgs(argnlist=[LatexGroupNode(pos=8, len=11,
     nodelist=[LatexCharsNode(pos=9, len=9, chars='Hi there!')],
     delimiters=('{', '}'))], argspec='{'), macro_post_space='')
-    >>> nodelist[5].isNodeType(LatexEnvironmentNode)
+    >>> isinstance(nodelist[5], LatexEnvironmentNode)
     True
     >>> nodelist[5].environmentname
     'enumerate'

--- a/pylatexenc/latexwalker/_helpers.py
+++ b/pylatexenc/latexwalker/_helpers.py
@@ -93,33 +93,33 @@ def nodelist_to_latex(nodelist):
     for n in nodelist:
         if n is None:
             continue
-        if n.isNodeType(LatexCharsNode):
+        if isinstance(n, LatexCharsNode):
             latex += n.chars
             continue
 
-        if n.isNodeType(LatexMacroNode):
+        if isinstance(n, LatexMacroNode):
             latex += r'\%s%s%s' %(n.macroname, n.macro_post_space, add_args(n.nodeargd))
             continue
 
-        if n.isNodeType(LatexSpecialsNode):
+        if isinstance(n, LatexSpecialsNode):
             latex += r'%s%s' %(n.specials_chars, add_args(n.nodeargd))
             continue
         
-        if n.isNodeType(LatexCommentNode):
+        if isinstance(n, LatexCommentNode):
             latex += '%'+n.comment+n.comment_post_space
             continue
         
-        if n.isNodeType(LatexGroupNode):
+        if isinstance(n, LatexGroupNode):
             latex += n.delimiters[0] + nodelist_to_latex(n.nodelist) + n.delimiters[1]
             continue
         
-        if n.isNodeType(LatexEnvironmentNode):
+        if isinstance(n, LatexEnvironmentNode):
             latex += r'\begin{%s}%s' %(n.envname, add_args(n.nodeargd))
             latex += nodelist_to_latex(n.nodelist)
             latex += r'\end{%s}' %(n.envname)
             continue
         
-        if n.isNodeType(LatexMathNode):
+        if isinstance(n, LatexMathNode):
             latex += n.delimiters[0] + nodelist_to_latex(n.nodelist) + n.delimiters[1]
             continue
         
@@ -171,28 +171,28 @@ def disp_node(n, indent=0, context='* ', skip_group=False):
 
     if n is None:
         title = '<None>'
-    elif n.isNodeType(LatexCharsNode):
+    elif isinstance(n, LatexCharsNode):
         title = repr(n.chars)
-    elif n.isNodeType(LatexMacroNode):
+    elif isinstance(n, LatexMacroNode):
         title = '\\'+n.macroname
         add_args()
-    elif n.isNodeType(LatexSpecialsNode):
+    elif isinstance(n, LatexSpecialsNode):
         title = n.specials_chars + ' (specials)'
         add_args()
-    elif n.isNodeType(LatexCommentNode):
+    elif isinstance(n, LatexCommentNode):
         title = '%' + n.comment.strip()
-    elif n.isNodeType(LatexGroupNode):
+    elif isinstance(n, LatexGroupNode):
         if (skip_group):
             for nn in n.arg:
                 disp_node(nn, indent=indent, context=context)
             return
         title = 'Group: '
         iterchildren.append(('* ', n.nodelist, False))
-    elif n.isNodeType(LatexEnvironmentNode):
+    elif isinstance(n, LatexEnvironmentNode):
         title = '\\begin{%s}' %(n.environmentname)
         add_args()
         iterchildren.append(('* ', n.nodelist, False))
-    elif n.isNodeType(LatexMathNode):
+    elif isinstance(n, LatexMathNode):
         title = n.delimiters[0]+n.displaytype+' math'+n.delimiters[1]
         iterchildren.append(('* ', n.nodelist, False))
     else:

--- a/pylatexenc/latexwalker/_helpers.py
+++ b/pylatexenc/latexwalker/_helpers.py
@@ -123,7 +123,7 @@ def nodelist_to_latex(nodelist):
             latex += n.delimiters[0] + nodelist_to_latex(n.nodelist) + n.delimiters[1]
             continue
         
-        latex += "<[UNKNOWN LATEX NODE: \'%s\']>"%(n.nodeType().__name__)
+        latex += "<[UNKNOWN LATEX NODE: \'%s\']>"%(type(n).__name__)
 
     return latex
     
@@ -196,7 +196,7 @@ def disp_node(n, indent=0, context='* ', skip_group=False):
         title = n.delimiters[0]+n.displaytype+' math'+n.delimiters[1]
         iterchildren.append(('* ', n.nodelist, False))
     else:
-        print("UNKNOWN NODE TYPE: %s"%(n.nodeType().__name__))
+        print("UNKNOWN NODE TYPE: %s"%(type(n).__name__))
 
     print(' '*indent + context + title + '  '+comment)
 

--- a/pylatexenc/latexwalker/_types.py
+++ b/pylatexenc/latexwalker/_types.py
@@ -284,7 +284,7 @@ class LatexNode(object):
     """
     Represents an abstract 'node' of the latex document.
 
-    Use :py:meth:`nodeType()` to figure out what type of node this is, and
+    Use :py:meth:`type()` to figure out what type of node this is, and
     :py:meth:`isinstance()` to test whether it is of a given type.
 
     You should use :py:meth:`LatexWalker.make_node()` to create nodes, so that
@@ -344,6 +344,11 @@ class LatexNode(object):
         :py:class:`~pylatexenc.latexwalker.LatexCharsNode`,
         :py:class:`~pylatexenc.latexwalker.LatexGroupNode`, etc.
         """
+        warnings.warn(
+            # Feb 2022
+            "nodeType() is deprecated. Use the built-in type() instead.",
+            DeprecationWarning
+        )
         return LatexNode
 
     def isNodeType(self, t):
@@ -354,7 +359,7 @@ class LatexNode(object):
         """
         warnings.warn(
             # Feb 2022
-            "isNodeType() is deprecated. Use the built-in isinstance(node, class)",
+            "isNodeType() is deprecated. Use the built-in isinstance(node, class) instead.",
             DeprecationWarning
         )
         return isinstance(self, t)
@@ -372,7 +377,7 @@ class LatexNode(object):
 
     def __eq__(self, other):
         return other is not None  and  \
-            self.nodeType() == other.nodeType()  and  \
+            type(self) == type(other)  and  \
             other.parsing_state is self.parsing_state and \
             other.pos == self.pos and \
             other.len == self.len and \
@@ -391,7 +396,7 @@ class LatexNode(object):
         return self.__repr__()
     def __repr__(self):
         return (
-            self.nodeType().__name__ + "(" +
+            type(self).__name__ + "(" +
             "parsing_state=<parsing state {}>, ".format(id(self.parsing_state)) +
             ", ".join([ "%s=%r"%(k,getattr(self,k))  for k in self._fields ]) +
             ")"
@@ -415,6 +420,11 @@ class LatexCharsNode(LatexNode):
         self.chars = chars
 
     def nodeType(self):
+        warnings.warn(
+            # Feb 2022
+            "nodeType() is deprecated. Use the built-in type() instead.",
+            DeprecationWarning
+        )
         return LatexCharsNode
 
 
@@ -451,6 +461,11 @@ class LatexGroupNode(LatexNode):
         self.delimiters = delimiters
 
     def nodeType(self):
+        warnings.warn(
+            # Feb 2022
+            "nodeType() is deprecated. Use the built-in type() instead.",
+            DeprecationWarning
+        )
         return LatexGroupNode
 
 
@@ -480,6 +495,11 @@ class LatexCommentNode(LatexNode):
         self.comment_post_space = comment_post_space
 
     def nodeType(self):
+        warnings.warn(
+            # Feb 2022
+            "nodeType() is deprecated. Use the built-in type() instead.",
+            DeprecationWarning
+        )
         return LatexCommentNode
 
 
@@ -558,6 +578,11 @@ class LatexMacroNode(LatexNode):
         self.nodeargs = nodeargs
 
     def nodeType(self):
+        warnings.warn(
+            # Feb 2022
+            "nodeType() is deprecated. Use the built-in type() instead.",
+            DeprecationWarning
+        )
         return LatexMacroNode
 
 
@@ -636,6 +661,11 @@ class LatexEnvironmentNode(LatexNode):
         self.args = args
 
     def nodeType(self):
+        warnings.warn(
+            # Feb 2022
+            "nodeType() is deprecated. Use the built-in type() instead.",
+            DeprecationWarning
+        )
         return LatexEnvironmentNode
 
 
@@ -679,6 +709,11 @@ class LatexSpecialsNode(LatexNode):
         self.nodeargd = nodeargd
 
     def nodeType(self):
+        warnings.warn(
+            # Feb 2022
+            "nodeType() is deprecated. Use the built-in type() instead.",
+            DeprecationWarning
+        )
         return LatexSpecialsNode
 
 
@@ -721,6 +756,11 @@ class LatexMathNode(LatexNode):
         self.delimiters = delimiters
 
     def nodeType(self):
+        warnings.warn(
+            # Feb 2022
+            "nodeType() is deprecated. Use the built-in type() instead.",
+            DeprecationWarning
+        )
         return LatexMathNode
 
 

--- a/pylatexenc/latexwalker/_types.py
+++ b/pylatexenc/latexwalker/_types.py
@@ -31,6 +31,8 @@ from __future__ import print_function, unicode_literals
 
 from ..macrospec import _parsedargs as macrospec_parsedargs
 
+import warnings
+
 
 # for Py3
 _basestring = str
@@ -283,7 +285,7 @@ class LatexNode(object):
     Represents an abstract 'node' of the latex document.
 
     Use :py:meth:`nodeType()` to figure out what type of node this is, and
-    :py:meth:`isNodeType()` to test whether it is of a given type.
+    :py:meth:`isinstance()` to test whether it is of a given type.
 
     You should use :py:meth:`LatexWalker.make_node()` to create nodes, so that
     the latex walker has the opportunity to do some additional setting up.
@@ -350,6 +352,11 @@ class LatexNode(object):
         must be a Python class such as,
         e.g. :py:class:`~pylatexenc.latexwalker.LatexGroupNode`.
         """
+        warnings.warn(
+            # Feb 2022
+            "isNodeType() is deprecated. Use the built-in isinstance(node, class)",
+            DeprecationWarning
+        )
         return isinstance(self, t)
 
     def latex_verbatim(self):

--- a/test/test_latexwalker.py
+++ b/test/test_latexwalker.py
@@ -1279,9 +1279,9 @@ int foo() {
                 (argd, npos, nlen) = super(MySimpleNewcommandArgsParser, self).parse_args(
                     w=w, pos=pos, parsing_state=parsing_state, **kwargs
                 )
-                if argd.argnlist[1].isNodeType(LatexGroupNode):
+                if isinstance(argd.argnlist[1], LatexGroupNode):
                     argd.argnlist[1] = argd.argnlist[1].nodelist[0] # {\command} -> \command
-                assert argd.argnlist[1].isNodeType(LatexMacroNode)
+                assert isinstance(argd.argnlist[1], LatexMacroNode)
                 argd.argnlist[1].nodeargd = None # hmmm, we should really have a
                                                  # custom parser here to read a
                                                  # single token

--- a/tools/gen_l2t_from_lenc.py
+++ b/tools/gen_l2t_from_lenc.py
@@ -28,7 +28,7 @@ def extract_symbol_node(nodelist, uni, latex):
 
     thenode = nodelist[0]
 
-    if not thenode.isNodeType(latexwalker.LatexMacroNode):
+    if not isinstance(thenode, latexwalker.LatexMacroNode):
         logger.warning("Got node that is not a macro, skipping (%s): %s = %r",
                        chr(uni), latex, thenode)
         return
@@ -42,7 +42,7 @@ def extract_symbol_node(nodelist, uni, latex):
             return
 
         argnode = thenode.nodeargd.argnlist[0]
-        if argnode.isNodeType(latexwalker.LatexGroupNode):
+        if isinstance(argnode, latexwalker.LatexGroupNode):
             argnodelist = argnode.nodelist
         else:
             argnodelist = [ argnode ]


### PR DESCRIPTION
Not only did those classes not follow naming conventions (`is_node_type`, `node_type`), but they're also easily replacable by standard functions. _Explicit is better than implicit_, as the Zen of Python says, so here's a PR that deprecates the methods.