### PR TITLE
test non-EOL python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,11 @@ python:
   - "2.7"
   - "3.4"
   - "3.6"
+  - "3.7*
+  - "3.8"
+  - "3.9"
+  - "3.10"
+  
 
 # command to run tests
 script:


### PR DESCRIPTION
Anything <3.7 could probably be dropped - but I did not want to jump ahead...

I guess this should also close #77