### PR TITLE
fix: repeated verbatim arguments using depth

### DIFF
--- a/pylatexenc/latexnodes/parsers/_verbatim.py
+++ b/pylatexenc/latexnodes/parsers/_verbatim.py
@@ -218,6 +218,8 @@ class LatexDelimitedVerbatimParser(LatexVerbatimBaseParser):
 
 
     def parse(self, latex_walker, token_reader, parsing_state, **kwargs):
+        # Reset depth counter (may be dirty from prior use)
+        self.depth_counter = 1
         
         verbatim_info = LatexVerbatimBaseParser.VerbatimInfo()
 

--- a/test/test_latexnodes_parsers_verbatim.py
+++ b/test/test_latexnodes_parsers_verbatim.py
@@ -297,7 +297,69 @@ verbatim>"""
                 pos_end=10,
             )
         )
-        
+
+    def test_nested_delims_repeated_use(self):
+        latextext = "{verbatim}"
+
+        tr = LatexTokenReader(latextext)
+        ps = ParsingState(s=latextext, latex_context=DummyLatexContextDb())
+        lw = DummyWalker()
+
+        parser = LatexDelimitedVerbatimParser()
+
+        node, parsing_state_delta = lw.parse_content(parser, token_reader=tr, parsing_state=ps)
+
+        vps = node.nodelist[0].parsing_state
+
+        self.assertEqual(
+            node,
+            LatexGroupNode(
+                parsing_state=ps,
+                delimiters=('{','}'),
+                nodelist=LatexNodeList([
+                    LatexCharsNode(
+                        parsing_state=vps,
+                        chars='verbatim',
+                        pos=1,
+                        pos_end=9,
+                    )
+                ]),
+                pos=0,
+                pos_end=10,
+            )
+        )
+
+        # Below we re-use `parser` to ensure that it can be invoked repeatedly and still report appropriately.
+        latextext = "{hello{}world}"
+
+        tr = LatexTokenReader(latextext)
+        ps = ParsingState(s=latextext, latex_context=DummyLatexContextDb())
+        lw = DummyWalker()
+
+        # Intentionally re-using same `parser` object
+
+        node, parsing_state_delta = lw.parse_content(parser, token_reader=tr, parsing_state=ps)
+
+        vps = node.nodelist[0].parsing_state
+
+        self.assertEqual(
+            node,
+            LatexGroupNode(
+                parsing_state=ps,
+                delimiters=('{','}'),
+                nodelist=LatexNodeList([
+                    LatexCharsNode(
+                        parsing_state=vps,
+                        chars='hello{}world',
+                        pos=1,
+                        pos_end=13,
+                    )
+                ]),
+                pos=0,
+                pos_end=14,
+            )
+        )
+
 
 
 class TestLatexVerbatimEnvironmentContentsParser(unittest.TestCase):


### PR DESCRIPTION
Fixes an issue related to `verbatim` formatted arguments failing to parse. Consider documents which define a macro which accepts a verbatim argument, for example `\my_macro{..}`. The macro may accept embedded `{}` blocks, for example: `\my_macro{foo{bar}}`. This is valid LaTeX and the argument should be parsed literally as `'foo{bar}'`.

The issue arises because the verbatim parser tracks depth via an instance variable `depth_counter`. It is initialized to `depth_counter = 1`. However, after parsing the first verbatim argument it decreases to `0`, then after the following it decreases again to `-1`, etc.

This causes early termination of parsing in subsequent verbatim parses which make meaningful use of the depth counter, and the remainder of the document will fail to parse correctly.

For example, the following would fail to parse correctly: `\my_macro{foo} \my_macro{bar{}}`.

The fix is to reset the depth counter to `1` whenever the parsing procedure begins.