### PR TITLE
fix: empty matrix or array environment crashes latex_to_text

### DIFF
--- a/pylatexenc/latex2text/__init__.py
+++ b/pylatexenc/latex2text/__init__.py
@@ -393,8 +393,9 @@ def fmt_matrix_environment_node(node, l2tobj):
 
     state.new_row() # finish the last row
 
-    # now format the contents as array --
-    max_char_width = max( ( len(x)  for row in state.matrix_rows  for x in row ) )
+    # now format the contents as array -- default=0 for an empty matrix/array
+    max_char_width = max( ( len(x)  for row in state.matrix_rows  for x in row ),
+                          default=0 )
     matrix_contents = "; ".join( (
         " ".join( (
             x.rjust(max_char_width, ' ')

--- a/test/test_2_latex2text.py
+++ b/test/test_2_latex2text.py
@@ -614,6 +614,20 @@ above. """
                 "[      1      2 abcdef;      3      4 ]"
             )
 
+    def test_repl_matrix_environment_empty(self):
+
+        # an empty matrix/array is valid LaTeX and must not raise ValueError
+        for env, arg in (('array', '{c}'), ('array', '{cc}'), ('pmatrix', ''),
+                          ('bmatrix', ''), ('smallmatrix', ''),
+                          ('psmallmatrix', ''), ('bsmallmatrix', '')):
+            self.assertEqual(
+                LatexNodes2Text().latex_to_text(
+                    r"\begin{%(env)s}%(arg)s\end{%(env)s}"
+                    %{'env':env,'arg':arg}
+                ),
+                "[  ]"
+            )
+
     def test_repl_doc_title(self):
 
         # test that \title/\author/\date work and produce something reasonable


### PR DESCRIPTION
`latex_to_text()` raises `ValueError: max() iterable argument is empty` on an empty matrix or array. The six registered delimited environments (array, pmatrix, bmatrix, smallmatrix, psmallmatrix, bsmallmatrix) all route through `fmt_matrix_environment_node`, which computes `max(len(x) for row in state.matrix_rows for x in row)` with no default, so an empty body raises. An empty pmatrix/array is valid LaTeX, and a plain `matrix` env already degrades to '' via generic handling.

Passing `default=0` to `max()` at that single choke point fixes all six: empty environments now render as '[  ]', consistent with the non-empty '[ a b; c d ]' form, and non-empty output is unchanged.

```python
from pylatexenc.latex2text import LatexNodes2Text
LatexNodes2Text().latex_to_text(r'\begin{pmatrix}\end{pmatrix}')  # ValueError before, '[  ]' after
```