### PR TITLE
fix: register href macro so latex_to_text can read its args

### DIFF
--- a/pylatexenc/latexwalker/_defaultspecs.py
+++ b/pylatexenc/latexwalker/_defaultspecs.py
@@ -156,6 +156,7 @@ specs = [
             std_macro('Cref', False, 1),
             std_macro('eqref', False, 1),
             std_macro('url', False, 1),
+            std_macro('href', False, 2),
             std_macro('hypersetup', False, 1),
             std_macro('footnote', True, 1),
 

--- a/test/test_2_latex2text.py
+++ b/test/test_2_latex2text.py
@@ -771,6 +771,13 @@ The Title
         self.assertEqual(a2, b2)
 
 
+    def test_href(self):
+        self.assertEqual(
+            LatexNodes2Text().latex_to_text(r'\href{http://example.com}{click}'),
+            'click <http://example.com>'
+        )
+
+
 if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)
     unittest.main()


### PR DESCRIPTION
LatexNodes2Text latex_to_text href hits IndexError when \\href{url}{text} argnlist short. This PR fixes the regression with a focused test covering the case.
