### PR TITLE
Fix LatexWalkerNodesParseError kwargs for unexpected math mode

### DIFF
--- a/pylatexenc/latexnodes/parsers/_expression.py
+++ b/pylatexenc/latexnodes/parsers/_expression.py
@@ -406,8 +406,8 @@ class LatexExpressionParser(LatexParserBase):
                                                         pos_end=tok.pos_end)
                 
             raise LatexWalkerNodesParseError(
-                "Unexpected math mode delimiter ‘{}’, was expecting a LaTeX expression"
-                .format(tok.arg),
+                msg=("Unexpected math mode delimiter ‘{}’, was expecting a LaTeX expression"
+                     .format(tok.arg)),
                 pos=tok.pos,
                 recovery_nodes=recovery_nodes,
                 recovery_past_token=tok,

--- a/test/test_latexnodes_parsers_expression.py
+++ b/test/test_latexnodes_parsers_expression.py
@@ -8,6 +8,7 @@ from pylatexenc.latexnodes.parsers._expression import (
 
 from pylatexenc.latexnodes import (
     LatexWalkerParseError,
+    LatexWalkerNodesParseError,
     LatexTokenReader,
     LatexToken,
     ParsingState,
@@ -340,6 +341,23 @@ class TestLatexExpression(unittest.TestCase):
                 pos_end=14+20,
             ),
         )
+
+
+    def test_math_mode_delimiter_raises_nodes_parse_error(self):
+        # Positional msg used to collide with recovery_nodes= (TypeError).
+        latextext = '$'
+        tr = LatexTokenReader(latextext)
+        ps = ParsingState(s=latextext, latex_context=DummyLatexContextDb())
+        lw = DummyWalker()
+        parser = LatexExpressionParser()
+
+        with self.assertRaises(LatexWalkerNodesParseError) as cm:
+            lw.parse_content(parser, token_reader=tr, parsing_state=ps)
+
+        exc = cm.exception
+        self.assertIn('math mode delimiter', exc.msg)
+        self.assertIsNotNone(exc.recovery_nodes)
+        self.assertEqual(exc.recovery_nodes.chars, '$')
 
 
 


### PR DESCRIPTION
LatexExpressionParser mathmode LatexWalkerNodesParseError hits TypeError when \\frac a$ recovery_nodes duplicate kwarg. This PR fixes the regression with a focused test covering the case.; implementing
