### PR TITLE
Fix \title, \author and \date with an optional short argument

### DIFF
--- a/pylatexenc/latex2text/_defaultspecs.py
+++ b/pylatexenc/latex2text/_defaultspecs.py
@@ -222,11 +222,11 @@ _latex_specs_approximations = {
     ] + [ MacroTextSpec(x, simplify_repl=y) for x, y in (
 
         ('title', lambda n, l2tobj: \
-         setattr(l2tobj, '_doc_title', l2tobj.nodelist_to_text(n.nodeargd.argnlist[0:1]))),
+         setattr(l2tobj, '_doc_title', l2tobj.nodelist_to_text(n.nodeargd.argnlist[1:2]))),
         ('author', lambda n, l2tobj: \
-         setattr(l2tobj, '_doc_author', l2tobj.nodelist_to_text(n.nodeargd.argnlist[0:1]))),
+         setattr(l2tobj, '_doc_author', l2tobj.nodelist_to_text(n.nodeargd.argnlist[1:2]))),
         ('date', lambda n, l2tobj: \
-         setattr(l2tobj, '_doc_date', l2tobj.nodelist_to_text(n.nodeargd.argnlist[0:1]))),
+         setattr(l2tobj, '_doc_date', l2tobj.nodelist_to_text(n.nodeargd.argnlist[1:2]))),
         ('maketitle', lambda n, l2tobj: \
          _format_maketitle(getattr(l2tobj, '_doc_title', r'[NO \title GIVEN]'),
                            getattr(l2tobj, '_doc_author', r'[NO \author GIVEN]'),

--- a/pylatexenc/latexwalker/_defaultspecs.py
+++ b/pylatexenc/latexwalker/_defaultspecs.py
@@ -203,10 +203,12 @@ specs = [
 
             MacroSpec('mbox', arguments_spec_list=[ _arg_textmode('{') ]),
 
-            # \title, \author, \date
-            MacroSpec('title', '{'),
-            MacroSpec('author', '{'),
-            MacroSpec('date', '{'),
+            # \title, \author, \date; each accepts an optional "short" form
+            # argument (e.g. \title[short title]{full title}) as provided by
+            # beamer and by the standard classes' \and-aware variants.
+            MacroSpec('title', '[{'),
+            MacroSpec('author', '[{'),
+            MacroSpec('date', '[{'),
 
             # (Note: single backslash) end of line with optional no-break ('*') and
             # additional vertical spacing, e.g. \\*[2mm]

--- a/test/test_2_latex2text.py
+++ b/test/test_2_latex2text.py
@@ -933,6 +933,29 @@ The Title
 """ % { 'today': today, 'eqhrule': eqhrule }
         )
 
+    def test_repl_doc_title_optional_short_arg(self):
+
+        # \title[short]{full}, \author[short]{full} and \date[short]{full}:
+        # the optional "short" argument must be consumed as an argument and the
+        # mandatory argument used for the rendered title block.
+
+        self.assertEqualUpToWhitespace(
+                LatexNodes2Text().latex_to_text(
+                    r"""
+\title[Short Title]{The Title}
+\author[T. A.]{The Author(s)}
+\date[2020]{July 4, 2020}
+\maketitle
+"""
+                ),
+            r"""
+The Title
+    The Author(s)
+    July 4, 2020
+=================
+"""
+        )
+
 
     @unittest.skipIf( sys.maxunicode < 0x10FFFF,
                       "no math alphabets on narrow python builds")


### PR DESCRIPTION
Closes #114.

`\title[short]{full}` (and likewise `\author` / `\date`) did not declare the optional argument in the latexwalker spec, so the `[short]` part stayed as plain character nodes and the mandatory argument was never picked up — `latex_to_text()` returned the raw `short]full` text and `\maketitle` rendered a stray `[`. Declaring the optional argument (`'[{'`) and reading the mandatory one at index 1 in the latex2text specs fixes both the bracketed and plain forms.

Regression test added in `test_2_latex2text.py`; it fails on master and passes with the fix, and the full suite (342 tests) is green.
